### PR TITLE
Add meta data for Zenodo

### DIFF
--- a/.zenodo.json
+++ b/.zenodo.json
@@ -1,0 +1,14 @@
+{
+  "creators":
+  [
+		{
+      "name": "IEA-ETSAP"
+    }
+  ],
+  
+  "license": "GPL-3.0",
+  
+  "title": "TIMES Source Code",
+  
+  "keywords": ["TIMES", "optimisation", "energy system model", "bottom-up model", "open source"]
+}

--- a/.zenodo.json
+++ b/.zenodo.json
@@ -1,14 +1,19 @@
 {
-  "creators":
-  [
-		{
+  "creators": [
+    {
       "name": "IEA-ETSAP"
     }
   ],
-  
+
   "license": "GPL-3.0",
-  
-  "title": "TIMES Source Code",
-  
-  "keywords": ["TIMES", "optimisation", "energy system model", "bottom-up model", "open source"]
+
+  "title": "TIMES Model Generator",
+
+  "keywords": [
+    "TIMES",
+    "optimisation",
+    "energy system model",
+    "bottom-up model",
+    "open source"
+  ]
 }


### PR DESCRIPTION
@Antti-L, @ggiannakidis this pull request proposes to add a file to control what information appears on the Zenodo record upon every release. It is similar to this version that we edited manually: https://zenodo.org/record/6412545, except:
- the license should now appear correctly,
- keywords would be included (please check and edit),
- the title **TIMES Source Code** instead of **TIMES Version x.x.x**, because Zenodo automatically includes version as **(vx.x.x.)** after the title (please check and edit)
